### PR TITLE
Small readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yarn
 yarn dev
 ```
 
-See [the diagram](https://github.com/steveruizok/kdtype/raw/main/game/src/diagram.tldr).
+See [the diagram](https://github.com/steveruizok/kdtype/raw/main/src/game/diagram.tldr).
 
 ## Contribution
 


### PR DESCRIPTION
The link on the readme does not point to the diagram you intend to show.

Not sure if this fixes it, however.